### PR TITLE
Tariff book agr nye electric sc1 v0.99.7 dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # macos file
 .DS_Store.DS_Store
+
+#Oxygen backup files
+*.xml.bak

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,8 @@ cython_debug/
 #.idea/
 
 # macos file
-.DS_Store.DS_Store
+.DS_Store
+
 
 #Oxygen backup files
 *.xml.bak

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tariffBooks xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Flux-Tailor/rate-plan-schema/refs/tags/v0.99.7-dev/tariff_books.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Flux-Tailor/rate-plan-schema/refs/tags/v0.99.7-dev/tariff_books.xsd">
     <tariffBook isReplacementRecord="false" isDeletedRecord="false">
         <utilityInfo>
             <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
@@ -13,7 +13,7 @@
         <sourceURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</sourceURL>
         <dataCreationMethod>Manual</dataCreationMethod>
         <dataDownloadURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</dataDownloadURL>
-        
+
         <effectivePeriod>
             <startDate>2010-01-01</startDate>
         </effectivePeriod>
@@ -39,8 +39,8 @@
                             <status>EFFECTIVE</status>
                             <revisionNumber>5</revisionNumber>
                             <supersedingRevisionNumber>4</supersedingRevisionNumber>
-                        </startLeafMetadata>                        
-                        <endLeafNumber>127</endLeafNumber>     
+                        </startLeafMetadata>
+                        <endLeafNumber>127</endLeafNumber>
                     </tariffBookLeafRange>
                 </tariffBookLeafRanges>
                 <rates>
@@ -64,248 +64,486 @@
                         </tariffBookLeafRanges>
                         <ratePlans>
                             <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
-                                        <ratePlanIdentifiers>
-                                            <serviceClassNumber>1</serviceClassNumber>
-                                            <rateCode>SC01</rateCode>
-                                            <ratePlanCodeUnique>ERS-AGR-NYE-SC01-RES1</ratePlanCodeUnique>
-                                        </ratePlanIdentifiers> 
-                                        <commodity>electricityPrimaryMetered</commodity>
-                                        <utilityInfo>
-                                            <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
-                                            <organizationType>DistributedSystemPlatformProvider</organizationType>
-                                        </utilityInfo>
-                                        <ratePlanApplicability>
-                                            <modelComponents>
-                                                <hasIcapTag>false</hasIcapTag>
-                                                <hasRetailSupply>false</hasRetailSupply>
-                                                <hasServiceTiers>true</hasServiceTiers>
-                                                <hasTimeOfUsePricing>false</hasTimeOfUsePricing>
-                                                <isRider>false</isRider>
-                                            </modelComponents>
-                                            <profile>
-                                                <customerClasses>
-                                                    <customerClass>Residential</customerClass>
-                                                    <!-- TODO: description removed since 0.99.5 --> 
-                                                </customerClasses>
-                                                <phases>
-                                                    <phase>none</phase>
-                                                    <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
-                                                </phases>
-                                                
-                                            </profile>
-                                        </ratePlanApplicability>
-                                        <provenanceMetadata>
-                                            <tariffBookLeafRanges>
-                                                <tariffBookLeafRange>
-                                                    <startLeafNumber>119</startLeafNumber>
-                                                    <startLeafMetadata>
-                                                        <receivedDate>2023-10-27</receivedDate>
-                                                        <initialEffectiveDate>2023-11-01</initialEffectiveDate>
-                                                        <effectiveDate>2023-11-01</effectiveDate>
-                                                        <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                                        <status>EFFECTIVE</status>
-                                                        <revisionNumber>18</revisionNumber>
-                                                        <supersedingRevisionNumber>16</supersedingRevisionNumber>
-                                                    </startLeafMetadata>
-                                                    <endLeafNumber>119</endLeafNumber>
-                                                </tariffBookLeafRange>
-                                            </tariffBookLeafRanges>
-                                            <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                            <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
-                                            <tariffStatementTypeCode></tariffStatementTypeCode>
-                                        </provenanceMetadata>
-                                        <name>Service Classification No. 1</name>
-                                        <validityStatusDates>
-                                            <effectivePeriod>
-                                                <startDate>2023-11-01</startDate>
-                                            </effectivePeriod>
-                                        </validityStatusDates>
-                                        <description>Residential Straight</description>                                     
-                                        <holidays>
-                                            <!-- TODO: Holidays missing from 0.99.5 version --> 
-                                            <holidayName>Christmas Day</holidayName>
-                                        </holidays>
-                                    
-                                        <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->    
-                                        <serviceTierThresholds>
-                                        </serviceTierThresholds>
-                                        
-                                        <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
-                                        <timeOfUsePeriods>
-                                            <timeOfUsePeriod>
-                                            </timeOfUsePeriod>
-                                        </timeOfUsePeriods>
-                                    <charges>         
-                                        <minimumCharge>
-                                            <effectivePeriod>
-                                                <startDate>2023-11-01</startDate>
-                                                <endDate>2024-04-30</endDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Customer Charge</name>
-                                            <value>19.00</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_billing_cycle</calculationMethod>
-                                                <measurementInterval>
-                                                    <calculationMode>PERIOD</calculationMode>
-                                                    <calcIntervalKind>MONTH</calcIntervalKind>
-                                                    <calcIntervalPer>1</calcIntervalPer>
-                                                </measurementInterval>
-                                            </measurementDefinition>
-                                        </minimumCharge>
-                                        <minimumCharge>
-                                            <effectivePeriod>
-                                                <startDate>2024-05-01</startDate>
-                                                <endDate>2025-04-30</endDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Customer Charge</name>
-                                            <value>19.00</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_billing_cycle</calculationMethod>
-                                                <measurementInterval>
-                                                    <calculationMode>PERIOD</calculationMode>
-                                                    <calcIntervalKind>MONTH</calcIntervalKind>
-                                                    <calcIntervalPer>1</calcIntervalPer>
-                                                </measurementInterval>
-                                            </measurementDefinition>
-                                        </minimumCharge>
-                                        <minimumCharge>
-                                            <effectivePeriod>
-                                                <startDate>2025-05-01</startDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Customer Charge</name>
-                                            <value>19.00</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_billing_cycle</calculationMethod>
-                                                <measurementInterval>
-                                                    <calculationMode>PERIOD</calculationMode>
-                                                    <calcIntervalKind>MONTH</calcIntervalKind>
-                                                    <calcIntervalPer>1</calcIntervalPer>
-                                                </measurementInterval>
-                                            </measurementDefinition>
-                                        </minimumCharge>    
-                                        <otherFixedCharge>
-                                            <effectivePeriod>
-                                                <startDate>2023-11-01</startDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Bill Issuance Charge</name>
-                                            <value>.89</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_billing_cycle</calculationMethod>
-                                                <measurementInterval>
-                                                    <calculationMode>TOTAL</calculationMode>
-                                                    <calcIntervalKind>PER-CYCLE</calcIntervalKind>
-                                                    <calcIntervalPer>1</calcIntervalPer>
-                                                </measurementInterval>
-                                            </measurementDefinition>
-                                        </otherFixedCharge>
-                                        <meteredServiceCharge>
-                                            <effectivePeriod>
-                                                <startDate>2023-11-01</startDate>
-                                                <endDate>2024-04-30</endDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Energy Charge</name>
-                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                <ratePlanIdentifiers>
+                                    <serviceClassNumber>1</serviceClassNumber>
+                                    <rateCode>SC01</rateCode>
+                                    <ratePlanCodeUnique>ERS-AGR-NYE-SC01-RES1</ratePlanCodeUnique>
+                                </ratePlanIdentifiers>
+                                <commodity>electricityPrimaryMetered</commodity>
+                                <utilityInfo>
+                                    <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
+                                    <organizationType>DistributedSystemPlatformProvider</organizationType>
+                                </utilityInfo>
+                                <ratePlanApplicability>
+                                    <modelComponents>
+                                        <hasIcapTag>false</hasIcapTag>
+                                        <hasRetailSupply>false</hasRetailSupply>
+                                        <hasServiceTiers>false</hasServiceTiers>
+                                        <hasTimeOfUsePricing>false</hasTimeOfUsePricing>
+                                        <isRider>false</isRider>
+                                    </modelComponents>
+                                    <profile>
+                                        <customerClasses>
+                                            <customerClass>Residential</customerClass>
+                                            <!-- TODO: description removed since 0.99.5 -->
+                                        </customerClasses>
+                                        <phases>
+                                            <phase>none</phase>
+                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
+                                        </phases>
+
+                                    </profile>
+                                </ratePlanApplicability>
+                                <provenanceMetadata>
+                                    <tariffBookLeafRanges>
+                                        <tariffBookLeafRange>
+                                            <startLeafNumber>119</startLeafNumber>
+                                            <startLeafMetadata>
+                                                <receivedDate>2023-10-27</receivedDate>
+                                                <initialEffectiveDate>2023-11-01</initialEffectiveDate>
+                                                <effectiveDate>2023-11-01</effectiveDate>
+                                                <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                                <status>EFFECTIVE</status>
+                                                <revisionNumber>18</revisionNumber>
+                                                <supersedingRevisionNumber>16</supersedingRevisionNumber>
+                                            </startLeafMetadata>
+                                            <endLeafNumber>119</endLeafNumber>
+                                        </tariffBookLeafRange>
+                                    </tariffBookLeafRanges>
+                                    <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                    <iedrRatePlanBrowserURL/>
+                                    <tariffStatementTypeCode/>
+                                </provenanceMetadata>
+                                <name>Service Classification No. 1</name>
+                                <validityStatusDates>
+                                    <effectivePeriod>
+                                        <startDate>2023-11-01</startDate>
+                                    </effectivePeriod>
+                                </validityStatusDates>
+                                <description>Residential Straight</description>
+                                <holidays>
+                                    <!-- TODO: Holidays missing from 0.99.5 version -->
+                                    <holidayName>Christmas Day</holidayName>
+                                </holidays>
+
+                                <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <serviceTierThresholds> </serviceTierThresholds>
+
+                                <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <timeOfUsePeriods>
+                                    <timeOfUsePeriod> </timeOfUsePeriod>
+                                </timeOfUsePeriods>
+                                <charges>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <otherFixedCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Bill Issuance Charge</name>
+                                        <value>.89</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>TOTAL</calculationMode>
+                                                <calcIntervalKind>PER-CYCLE</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </otherFixedCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
                                                 plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
                                                 customer’s bill shall not include the Make-Whole Rate.</description>
-                                            <value>0.06139</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_metered_quantity</calculationMethod>
-                                                <measurementSource>energy</measurementSource>
-                                                <unitOfMeasure>Wh</unitOfMeasure>
-                                            </measurementDefinition>
-                                        </meteredServiceCharge>
-                                        <meteredServiceCharge>
-                                            <effectivePeriod>
-                                                <startDate>2024-05-01</startDate>
-                                                <endDate>2025-04-30</endDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Energy Charge</name>
-                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                        <value>0.06139</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
                                                 plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
                                                 customer’s bill shall not include the Make-Whole Rate.</description>
-                                            <value>0.07618</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_metered_quantity</calculationMethod>
-                                                <measurementSource>energy</measurementSource>
-                                                <unitOfMeasure>Wh</unitOfMeasure>
-                                            </measurementDefinition>
-                                        </meteredServiceCharge>
-                                        <meteredServiceCharge>
-                                            <effectivePeriod>
-                                                <startDate>2025-05-01</startDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Energy Charge</name>
-                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                        <value>0.07618</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
                                                 plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
                                                 customer’s bill shall not include the Make-Whole Rate.</description>
-                                            <value>0.09507</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_metered_quantity</calculationMethod>
-                                                <measurementSource>energy</measurementSource>
-                                                <unitOfMeasure>Wh</unitOfMeasure>
-                                            </measurementDefinition>
-                                        </meteredServiceCharge>
-                                        <meteredServiceCharge>
-                                            <effectivePeriod>
-                                                <startDate>2023-11-01</startDate>
-                                                <endDate>2024-04-30</endDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Make-Whole Energy Charge</name>
-                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                        <value>0.09507</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
                                                 plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
                                                 customer’s bill shall not include the Make-Whole Rate.</description>
-                                            <value>0.00276</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_metered_quantity</calculationMethod>
-                                                <measurementSource>energy</measurementSource>
-                                                <unitOfMeasure>Wh</unitOfMeasure>
-                                            </measurementDefinition>
-                                        </meteredServiceCharge>
-                                        <meteredServiceCharge>
-                                            <effectivePeriod>
-                                                <startDate>2024-05-01</startDate>
-                                                <endDate>2025-04-30</endDate>
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Make-Whole Energy Charge</name>
-                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
                                                 plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
                                                 customer’s bill shall not include the Make-Whole Rate.</description>
-                                            <value>0.00276</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_metered_quantity</calculationMethod>
-                                                <measurementSource>energy</measurementSource>
-                                                <unitOfMeasure>Wh</unitOfMeasure>
-                                            </measurementDefinition>
-                                        </meteredServiceCharge>
-                                        <meteredServiceCharge>
-                                            <effectivePeriod>
-                                                <startDate>2025-05-01</startDate>
-                                                <endDate>2026-04-30</endDate> 
-                                            </effectivePeriod>
-                                            <statementComponent>delivery</statementComponent>
-                                            <name>Make-Whole Energy Charge</name>
-                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                            <endDate>2026-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
                                                 plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
                                                 customer’s bill shall not include the Make-Whole Rate.</description>
-                                            <value>0.00276</value>
-                                            <measurementDefinition>
-                                                <calculationMethod>by_metered_quantity</calculationMethod>
-                                                <measurementSource>energy</measurementSource>
-                                                <unitOfMeasure>Wh</unitOfMeasure>
-                                            </measurementDefinition>
-                                        </meteredServiceCharge>
-                                    </charges>   
-                                </ratePlan>
-                            </ratePlans>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                </charges>
+                            </ratePlan>
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                                <ratePlanIdentifiers>
+                                    <serviceClassNumber>1</serviceClassNumber>
+                                    <rateCode>SC01</rateCode>
+                                    <ratePlanCodeUnique>EDS-AGR-NYE-SC01-RES-001</ratePlanCodeUnique>
+                                </ratePlanIdentifiers>
+                                <commodity>electricityPrimaryMetered</commodity>
+                                <utilityInfo>
+                                    <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
+                                    <organizationType>DistributedSystemPlatformProvider</organizationType>
+                                </utilityInfo>
+                                <ratePlanApplicability>
+                                    <modelComponents>
+                                        <hasIcapTag>false</hasIcapTag>
+                                        <hasRetailSupply>false</hasRetailSupply>
+                                        <hasServiceTiers>false</hasServiceTiers>
+                                        <hasTimeOfUsePricing>false</hasTimeOfUsePricing>
+                                        <isRider>false</isRider>
+                                    </modelComponents>
+                                    <profile>
+                                        <customerClasses>
+                                            <customerClass>Residential</customerClass>
+                                            <!-- TODO: description removed since 0.99.5 -->
+                                        </customerClasses>
+                                        <phases>
+                                            <phase>none</phase>
+                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
+                                        </phases>
+
+                                    </profile>
+                                </ratePlanApplicability>
+                                <provenanceMetadata>
+                                    <tariffBookLeafRanges>
+                                        <tariffBookLeafRange>
+                                            <startLeafNumber>122</startLeafNumber>
+                                            <startLeafMetadata>
+                                                <receivedDate>2023-10-27</receivedDate>
+                                                <initialEffectiveDate>2023-11-01</initialEffectiveDate>
+                                                <effectiveDate>2023-11-01</effectiveDate>
+                                                <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                                <status>EFFECTIVE</status>
+                                                <revisionNumber>18</revisionNumber>
+                                                <supersedingRevisionNumber>16</supersedingRevisionNumber>
+                                            </startLeafMetadata>
+                                            <endLeafNumber>123</endLeafNumber>
+                                        </tariffBookLeafRange>
+                                    </tariffBookLeafRanges>
+                                    <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
+                                    <tariffStatementTypeCode>TODO</tariffStatementTypeCode>
+                                </provenanceMetadata>
+                                <name>Service Classification No. 1 NYSEG Supply Service (NSS)</name>
+                                <validityStatusDates>
+                                    <effectivePeriod>
+                                        <startDate>2023-11-01</startDate>
+                                    </effectivePeriod>
+                                </validityStatusDates>
+                                <description>Residential Straight</description>
+                                <holidays>
+                                    <!-- TODO: Holidays missing from 0.99.5 version -->
+                                    <holidayName>Christmas Day</holidayName>
+                                </holidays>
+
+                                <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <serviceTierThresholds> </serviceTierThresholds>
+
+                                <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <timeOfUsePeriods>
+                                    <timeOfUsePeriod> </timeOfUsePeriod>
+                                </timeOfUsePeriods>
+                                <charges>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <otherFixedCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Bill Issuance Charge</name>
+                                        <value>.89</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>TOTAL</calculationMode>
+                                                <calcIntervalKind>PER-CYCLE</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </otherFixedCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.06139</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>                                       
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.07618</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.09507</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                            <endDate>2026-04-30</endDate> 
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                </charges>
+                            </ratePlan>
+                        </ratePlans>
                     </rate>
                 </rates>
             </serviceClass>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -2,7 +2,7 @@
 <tariffBooks xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Flux-Tailor/rate-plan-schema/refs/tags/v0.99.7-dev/tariff_books.xsd">
-    <tariffBook isReplacementRecord="false" isDeletedRecord="false">
+    <tariffBook>
         <utilityInfo>
             <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
             <organizationType>DistributedSystemPlatformProvider</organizationType>
@@ -10,10 +10,10 @@
         <commodity>electricityPrimaryMetered</commodity>
         <dataSource>TariffBook</dataSource>
         <mediaType>application/pdf</mediaType>
+        <!-- TODO: URL pointed to github in v0.99.5.  Confirm this is correct sourceURL --> 
         <sourceURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</sourceURL>
         <dataCreationMethod>Manual</dataCreationMethod>
         <dataDownloadURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</dataDownloadURL>
-
         <effectivePeriod>
             <startDate>2010-01-01</startDate>
         </effectivePeriod>
@@ -22,8 +22,6 @@
         <dateTimeDataExtract>2024-12-18T13:00:00-05:00</dateTimeDataExtract>
         <dateTimeDataTransfer>2024-12-18T13:51:00-05:00</dateTimeDataTransfer>
         <updateFrequency>annually</updateFrequency>
-
-
         <serviceClasses>
             <serviceClass>
                 <serviceClassNumber>1</serviceClassNumber>
@@ -111,7 +109,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL/>
+                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
                                     <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1</name>
@@ -125,13 +123,11 @@
                                     <!-- TODO: Holidays missing from 0.99.5 version -->
                                     <holidayName>Christmas Day</holidayName>
                                 </holidays>
-
-                                <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
                                 <serviceTierThresholds> </serviceTierThresholds>
-
-                                <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
                                 <timeOfUsePeriods>
-                                    <timeOfUsePeriod> </timeOfUsePeriod>
+                                    <timeOfUsePeriod></timeOfUsePeriod>
                                 </timeOfUsePeriods>
                                 <charges>
                                     <minimumCharge>
@@ -365,11 +361,9 @@
                                     <!-- TODO: Holidays missing from 0.99.5 version -->
                                     <holidayName>Christmas Day</holidayName>
                                 </holidays>
-
-                                <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
                                 <serviceTierThresholds> </serviceTierThresholds>
-
-                                <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
                                 <timeOfUsePeriods>
                                     <timeOfUsePeriod> </timeOfUsePeriod>
                                 </timeOfUsePeriods>
@@ -588,7 +582,7 @@
                                                 <supersedingRevisionNumber>25</supersedingRevisionNumber>
                                             </startLeafMetadata>
                                             <endLeafNumber>123</endLeafNumber>
-                                            <!-- TODO: Is this correct? Maybe error in previous version -->
+                                            <!-- TODO: Is endLeafNumber correct? Maybe error in previous version -->
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
@@ -607,10 +601,10 @@
                                     <holidayName>Christmas Day</holidayName>
                                 </holidays>
 
-                                <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
                                 <serviceTierThresholds> </serviceTierThresholds>
 
-                                <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
                                 <timeOfUsePeriods>
                                     <timeOfUsePeriod> </timeOfUsePeriod>
                                 </timeOfUsePeriods>
@@ -784,7 +778,250 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                                <ratePlanIdentifiers>
+                                    <serviceClassNumber>1</serviceClassNumber>
+                                    <rateCode>SC01</rateCode>
+                                    <ratePlanCodeUnique>EDS-AGR-NYE-SC01-S-RES-001</ratePlanCodeUnique>
+                                </ratePlanIdentifiers>
+                                <commodity>electricityPrimaryMetered</commodity>
+                                <utilityInfo>
+                                    <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
+                                    <organizationType>DistributedSystemPlatformProvider</organizationType>
+                                </utilityInfo>
+                                <ratePlanApplicability>
+                                    <modelComponents>
+                                        <hasIcapTag>false</hasIcapTag>
+                                        <hasRetailSupply>false</hasRetailSupply>
+                                        <hasServiceTiers>false</hasServiceTiers>
+                                        <hasTimeOfUsePricing>false</hasTimeOfUsePricing>
+                                        <isRider>false</isRider>
+                                    </modelComponents>
+                                    <profile>
+                                        <customerClasses>
+                                            <customerClass>Residential</customerClass>
+                                            <!-- TODO: description removed since 0.99.5 -->
+                                        </customerClasses>
+                                        <phases>
+                                            <phase>none</phase>
+                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
+                                        </phases>
+                                    </profile>
+                                </ratePlanApplicability>
+                                <provenanceMetadata>
+                                    <tariffBookLeafRanges>
+                                        <tariffBookLeafRange>
+                                            <startLeafNumber>124</startLeafNumber>
+                                            <startLeafMetadata>
+                                                <receivedDate>2023-10-27</receivedDate>
+                                                <initialEffectiveDate>2023-11-01</initialEffectiveDate>
+                                                <effectiveDate>2023-11-01</effectiveDate>
+                                                <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                                <status>EFFECTIVE</status>
+                                                <revisionNumber>27</revisionNumber>
+                                                <supersedingRevisionNumber>25</supersedingRevisionNumber>
+                                            </startLeafMetadata>
+                                            <endLeafNumber>123</endLeafNumber>
+                                            <!-- TODO: Is endLeafNumber correct? Maybe error in previous version -->
+                                        </tariffBookLeafRange>
+                                    </tariffBookLeafRanges>
+                                    <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
+                                    <tariffStatementTypeCode>TODO</tariffStatementTypeCode>
+                                </provenanceMetadata>
+                                <name>Service Classification No. 1 - Seasonal NYSEG Supply Service (NSS)</name>
+                                <validityStatusDates>
+                                    <effectivePeriod>
+                                        <startDate>2023-11-01</startDate>
+                                    </effectivePeriod>
+                                </validityStatusDates>
+                                <description>Upon request, customers who, during a period of six or more consecutive months, make only occasional
+                                    (compared to the balance of the year) or no use of electric service at their premises may have their service
+                                    maintained throughout the period, not to exceed eight months, and shall be billed for the kWh consumed
+                                    during this period at the following unit prices per kWh: The Delivery Charge that appears on the
+                                    customer’s bill is the sum of the Energy Charge plus the Make-Whole Charge. Effective 11/01/23:
+                                    The total bill for delivery service, however, for the year shall in no case be less than $228.00 plus actual
+                                    billed Bill Issuance Charges.</description>
+                                <holidays>
+                                    <!-- TODO: Holidays missing from 0.99.5 version -->
+                                    <holidayName>Christmas Day</holidayName>
+                                </holidays>
+                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <serviceTierThresholds> </serviceTierThresholds>
+                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <timeOfUsePeriods>
+                                    <timeOfUsePeriod> </timeOfUsePeriod>
+                                </timeOfUsePeriods>
+                                <charges>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <otherFixedCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Bill Issuance Charge</name>
+                                        <value>.89</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>TOTAL</calculationMode>
+                                                <calcIntervalKind>PER-CYCLE</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </otherFixedCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Delivery Charges</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.06139</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>kWh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Delivery Charges</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.07618</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>kWh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Delivery Charges</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.09507</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>kWh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>kWh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>kWh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                            <endDate>2026-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>kWh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                </charges>
+                            </ratePlan>
                         </ratePlans>
                     </rate>
                 </rates>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -103,7 +103,7 @@
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
                                     <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode/>
+                                    <tariffStatementTypeCode></tariffStatementTypeCode>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1</name>
                                 <validityStatusDates>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -10,7 +10,6 @@
         <commodity>electricityPrimaryMetered</commodity>
         <dataSource>TariffBook</dataSource>
         <mediaType>application/pdf</mediaType>
-        <!-- TODO: URL pointed to github in v0.99.5.  Confirm this is correct sourceURL --> 
         <sourceURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</sourceURL>
         <dataCreationMethod>Manual</dataCreationMethod>
         <dataDownloadURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</dataDownloadURL>
@@ -61,7 +60,7 @@
                             </tariffBookLeafRange>
                         </tariffBookLeafRanges>
                         <ratePlans>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/146fbd5e-ef3f-441e-9168-01c9c3eaccf1">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -83,13 +82,7 @@
                                     <profile>
                                         <customerClasses>
                                             <customerClass>Residential</customerClass>
-                                            <!-- TODO: description removed since 0.99.5 -->
                                         </customerClasses>
-                                        <phases>
-                                            <phase>none</phase>
-                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
-                                        </phases>
-
                                     </profile>
                                 </ratePlanApplicability>
                                 <provenanceMetadata>
@@ -109,7 +102,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
+                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
                                     <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1</name>
@@ -119,16 +112,7 @@
                                     </effectivePeriod>
                                 </validityStatusDates>
                                 <description>Residential Straight</description>
-                                <holidays>
-                                    <!-- TODO: Holidays missing from 0.99.5 version -->
-                                    <holidayName>Christmas Day</holidayName>
-                                </holidays>
-                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
-                                <serviceTierThresholds> </serviceTierThresholds>
-                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
-                                <timeOfUsePeriods>
-                                    <timeOfUsePeriod></timeOfUsePeriod>
-                                </timeOfUsePeriods>
+
                                 <charges>
                                     <minimumCharge>
                                         <effectivePeriod>
@@ -299,7 +283,7 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/ca5be7ca-15ad-40c9-b8b2-4a87b6de6136">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -321,13 +305,7 @@
                                     <profile>
                                         <customerClasses>
                                             <customerClass>Residential</customerClass>
-                                            <!-- TODO: description removed since 0.99.5 -->
                                         </customerClasses>
-                                        <phases>
-                                            <phase>none</phase>
-                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
-                                        </phases>
-
                                     </profile>
                                 </ratePlanApplicability>
                                 <provenanceMetadata>
@@ -347,8 +325,8 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode>TODO</tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
+                                    <tariffStatementTypeCode></tariffStatementTypeCode>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 NYSEG Supply Service (NSS)</name>
                                 <validityStatusDates>
@@ -357,16 +335,6 @@
                                     </effectivePeriod>
                                 </validityStatusDates>
                                 <description>Residential Straight</description>
-                                <holidays>
-                                    <!-- TODO: Holidays missing from 0.99.5 version -->
-                                    <holidayName>Christmas Day</holidayName>
-                                </holidays>
-                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
-                                <serviceTierThresholds> </serviceTierThresholds>
-                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
-                                <timeOfUsePeriods>
-                                    <timeOfUsePeriod> </timeOfUsePeriod>
-                                </timeOfUsePeriods>
                                 <charges>
                                     <minimumCharge>
                                         <effectivePeriod>
@@ -537,7 +505,7 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/e9373145-70f3-441a-83ee-478af79d84ea">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -559,13 +527,7 @@
                                     <profile>
                                         <customerClasses>
                                             <customerClass>Residential</customerClass>
-                                            <!-- TODO: description removed since 0.99.5 -->
                                         </customerClasses>
-                                        <phases>
-                                            <phase>none</phase>
-                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
-                                        </phases>
-
                                     </profile>
                                 </ratePlanApplicability>
                                 <provenanceMetadata>
@@ -581,13 +543,12 @@
                                                 <revisionNumber>27</revisionNumber>
                                                 <supersedingRevisionNumber>25</supersedingRevisionNumber>
                                             </startLeafMetadata>
-                                            <endLeafNumber>123</endLeafNumber>
-                                            <!-- TODO: Is endLeafNumber correct? Maybe error in previous version -->
+                                            <endLeafNumber>124</endLeafNumber>
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode>TODO</tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
+                                    <tariffStatementTypeCode></tariffStatementTypeCode>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - ESCO Supply Service (ESS)</name>
                                 <validityStatusDates>
@@ -596,18 +557,6 @@
                                     </effectivePeriod>
                                 </validityStatusDates>
                                 <description>Residential Straight</description>
-                                <holidays>
-                                    <!-- TODO: Holidays missing from 0.99.5 version -->
-                                    <holidayName>Christmas Day</holidayName>
-                                </holidays>
-
-                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
-                                <serviceTierThresholds> </serviceTierThresholds>
-
-                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
-                                <timeOfUsePeriods>
-                                    <timeOfUsePeriod> </timeOfUsePeriod>
-                                </timeOfUsePeriods>
                                 <charges>
                                     <minimumCharge>
                                         <effectivePeriod>
@@ -778,7 +727,7 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/c44026f6-74d6-448c-a612-4d5cabb4994c">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -800,12 +749,7 @@
                                     <profile>
                                         <customerClasses>
                                             <customerClass>Residential</customerClass>
-                                            <!-- TODO: description removed since 0.99.5 -->
                                         </customerClasses>
-                                        <phases>
-                                            <phase>none</phase>
-                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
-                                        </phases>
                                     </profile>
                                 </ratePlanApplicability>
                                 <provenanceMetadata>
@@ -821,13 +765,12 @@
                                                 <revisionNumber>27</revisionNumber>
                                                 <supersedingRevisionNumber>25</supersedingRevisionNumber>
                                             </startLeafMetadata>
-                                            <endLeafNumber>123</endLeafNumber>
-                                            <!-- TODO: Is endLeafNumber correct? Maybe error in previous version -->
+                                            <endLeafNumber>124</endLeafNumber>
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode>TODO</tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
+                                    <tariffStatementTypeCode></tariffStatementTypeCode>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - Seasonal NYSEG Supply Service (NSS)</name>
                                 <validityStatusDates>
@@ -842,16 +785,6 @@
                                     customer’s bill is the sum of the Energy Charge plus the Make-Whole Charge. Effective 11/01/23:
                                     The total bill for delivery service, however, for the year shall in no case be less than $228.00 plus actual
                                     billed Bill Issuance Charges.</description>
-                                <holidays>
-                                    <!-- TODO: Holidays missing from 0.99.5 version -->
-                                    <holidayName>Christmas Day</holidayName>
-                                </holidays>
-                                <!-- TODO: No serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
-                                <serviceTierThresholds> </serviceTierThresholds>
-                                <!-- TODO: No timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
-                                <timeOfUsePeriods>
-                                    <timeOfUsePeriod> </timeOfUsePeriod>
-                                </timeOfUsePeriods>
                                 <charges>
                                     <minimumCharge>
                                         <effectivePeriod>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -104,7 +104,6 @@
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
                                     <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=ERS-AGR-NYE-SC01-RES1</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1</name>
                                 <validityStatusDates>
@@ -328,7 +327,6 @@
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
                                     <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=EDS-AGR-NYE-SC01-RES-001</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 NYSEG Supply Service (NSS)</name>
                                 <validityStatusDates>
@@ -551,7 +549,6 @@
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
                                     <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=ERS-AGR-NYE-SC01-S-RES-001</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - ESCO Supply Service (ESS)</name>
                                 <validityStatusDates>
@@ -773,8 +770,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=EDS-AGR-NYE-SC01-S-RES-001</iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode/>
+                                    <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=EDS-AGR-NYE-SC01-S-RES-001p</iedrRatePlanBrowserURL>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - Seasonal NYSEG Supply Service (NSS)</name>
                                 <validityStatusDates>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -461,7 +461,7 @@
                                         <effectivePeriod>
                                             <startDate>2024-05-01</startDate>
                                             <endDate>2025-04-30</endDate>
-                                        </effectivePeriod>                                       
+                                        </effectivePeriod>
                                         <statementComponent>delivery</statementComponent>
                                         <name>Energy Charge</name>
                                         <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
@@ -527,7 +527,7 @@
                                     <meteredServiceCharge>
                                         <effectivePeriod>
                                             <startDate>2025-05-01</startDate>
-                                            <endDate>2026-04-30</endDate> 
+                                            <endDate>2026-04-30</endDate>
                                         </effectivePeriod>
                                         <statementComponent>delivery</statementComponent>
                                         <name>Make-Whole Energy Charge</name>
@@ -543,6 +543,248 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                                <ratePlanIdentifiers>
+                                    <serviceClassNumber>1</serviceClassNumber>
+                                    <rateCode>SC01</rateCode>
+                                    <ratePlanCodeUnique>ERS-AGR-NYE-SC01-S-RES-001</ratePlanCodeUnique>
+                                </ratePlanIdentifiers>
+                                <commodity>electricityPrimaryMetered</commodity>
+                                <utilityInfo>
+                                    <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
+                                    <organizationType>DistributedSystemPlatformProvider</organizationType>
+                                </utilityInfo>
+                                <ratePlanApplicability>
+                                    <modelComponents>
+                                        <hasIcapTag>false</hasIcapTag>
+                                        <hasRetailSupply>false</hasRetailSupply>
+                                        <hasServiceTiers>false</hasServiceTiers>
+                                        <hasTimeOfUsePricing>false</hasTimeOfUsePricing>
+                                        <isRider>false</isRider>
+                                    </modelComponents>
+                                    <profile>
+                                        <customerClasses>
+                                            <customerClass>Residential</customerClass>
+                                            <!-- TODO: description removed since 0.99.5 -->
+                                        </customerClasses>
+                                        <phases>
+                                            <phase>none</phase>
+                                            <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
+                                        </phases>
+
+                                    </profile>
+                                </ratePlanApplicability>
+                                <provenanceMetadata>
+                                    <tariffBookLeafRanges>
+                                        <tariffBookLeafRange>
+                                            <startLeafNumber>124</startLeafNumber>
+                                            <startLeafMetadata>
+                                                <receivedDate>2023-10-27</receivedDate>
+                                                <initialEffectiveDate>2023-11-01</initialEffectiveDate>
+                                                <effectiveDate>2023-11-01</effectiveDate>
+                                                <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                                <status>EFFECTIVE</status>
+                                                <revisionNumber>27</revisionNumber>
+                                                <supersedingRevisionNumber>25</supersedingRevisionNumber>
+                                            </startLeafMetadata>
+                                            <endLeafNumber>123</endLeafNumber>
+                                            <!-- TODO: Is this correct? Maybe error in previous version -->
+                                        </tariffBookLeafRange>
+                                    </tariffBookLeafRanges>
+                                    <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                    <iedrRatePlanBrowserURL>TODO</iedrRatePlanBrowserURL>
+                                    <tariffStatementTypeCode>TODO</tariffStatementTypeCode>
+                                </provenanceMetadata>
+                                <name>Service Classification No. 1 - ESCO Supply Service (ESS)</name>
+                                <validityStatusDates>
+                                    <effectivePeriod>
+                                        <startDate>2023-11-01</startDate>
+                                    </effectivePeriod>
+                                </validityStatusDates>
+                                <description>Residential Straight</description>
+                                <holidays>
+                                    <!-- TODO: Holidays missing from 0.99.5 version -->
+                                    <holidayName>Christmas Day</holidayName>
+                                </holidays>
+
+                                <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->
+                                <serviceTierThresholds> </serviceTierThresholds>
+
+                                <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                <timeOfUsePeriods>
+                                    <timeOfUsePeriod> </timeOfUsePeriod>
+                                </timeOfUsePeriods>
+                                <charges>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <minimumCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Customer Charge</name>
+                                        <value>19.00</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>PERIOD</calculationMode>
+                                                <calcIntervalKind>MONTH</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </minimumCharge>
+                                    <otherFixedCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Bill Issuance Charge</name>
+                                        <value>.89</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_billing_cycle</calculationMethod>
+                                            <measurementInterval>
+                                                <calculationMode>TOTAL</calculationMode>
+                                                <calcIntervalKind>PER-CYCLE</calcIntervalKind>
+                                                <calcIntervalPer>1</calcIntervalPer>
+                                            </measurementInterval>
+                                        </measurementDefinition>
+                                    </otherFixedCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Delivery Charges</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.06139</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Delivery Charges</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.07618</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Delivery Charges</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.09507</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2023-11-01</startDate>
+                                            <endDate>2024-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2024-05-01</startDate>
+                                            <endDate>2025-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                    <meteredServiceCharge>
+                                        <effectivePeriod>
+                                            <startDate>2025-05-01</startDate>
+                                            <endDate>2026-04-30</endDate>
+                                        </effectivePeriod>
+                                        <statementComponent>delivery</statementComponent>
+                                        <name>Make-Whole Energy Charge</name>
+                                        <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                            plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                            customer’s bill shall not include the Make-Whole Rate.</description>
+                                        <value>0.00276</value>
+                                        <measurementDefinition>
+                                            <calculationMethod>by_metered_quantity</calculationMethod>
+                                            <measurementSource>energy</measurementSource>
+                                            <unitOfMeasure>Wh</unitOfMeasure>
+                                        </measurementDefinition>
+                                    </meteredServiceCharge>
+                                </charges>
+                            </ratePlan>
+
                         </ratePlans>
                     </rate>
                 </rates>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -103,7 +103,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL/>
+                                    <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=ERS-AGR-NYE-SC01-RES1</iedrRatePlanBrowserURL>
                                     <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1</name>
@@ -327,7 +327,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL/>
+                                    <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=EDS-AGR-NYE-SC01-RES-001</iedrRatePlanBrowserURL>
                                     <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 NYSEG Supply Service (NSS)</name>
@@ -550,7 +550,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL/>
+                                    <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=ERS-AGR-NYE-SC01-S-RES-001</iedrRatePlanBrowserURL>
                                     <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - ESCO Supply Service (ESS)</name>
@@ -773,7 +773,7 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL/>
+                                    <iedrRatePlanBrowserURL>https://iedr.nyserda.ny.gov/rate-plan/?rateId=EDS-AGR-NYE-SC01-S-RES-001</iedrRatePlanBrowserURL>
                                     <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - Seasonal NYSEG Supply Service (NSS)</name>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -60,7 +60,8 @@
                             </tariffBookLeafRange>
                         </tariffBookLeafRanges>
                         <ratePlans>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/146fbd5e-ef3f-441e-9168-01c9c3eaccf1">
+                            <ratePlan
+                                ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/146fbd5e-ef3f-441e-9168-01c9c3eaccf1">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -102,8 +103,8 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode></tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL/>
+                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1</name>
                                 <validityStatusDates>
@@ -283,7 +284,8 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/ca5be7ca-15ad-40c9-b8b2-4a87b6de6136">
+                            <ratePlan
+                                ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/ca5be7ca-15ad-40c9-b8b2-4a87b6de6136">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -325,8 +327,8 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode></tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL/>
+                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 NYSEG Supply Service (NSS)</name>
                                 <validityStatusDates>
@@ -505,7 +507,8 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/e9373145-70f3-441a-83ee-478af79d84ea">
+                            <ratePlan
+                                ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/e9373145-70f3-441a-83ee-478af79d84ea">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -547,8 +550,8 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode></tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL/>
+                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - ESCO Supply Service (ESS)</name>
                                 <validityStatusDates>
@@ -727,7 +730,8 @@
                                     </meteredServiceCharge>
                                 </charges>
                             </ratePlan>
-                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/c44026f6-74d6-448c-a612-4d5cabb4994c">
+                            <ratePlan
+                                ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/c44026f6-74d6-448c-a612-4d5cabb4994c">
                                 <ratePlanIdentifiers>
                                     <serviceClassNumber>1</serviceClassNumber>
                                     <rateCode>SC01</rateCode>
@@ -769,8 +773,8 @@
                                         </tariffBookLeafRange>
                                     </tariffBookLeafRanges>
                                     <dpsCaseNumber>22-E-0317</dpsCaseNumber>
-                                    <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
-                                    <tariffStatementTypeCode></tariffStatementTypeCode>
+                                    <iedrRatePlanBrowserURL/>
+                                    <tariffStatementTypeCode/>
                                 </provenanceMetadata>
                                 <name>Service Classification No. 1 - Seasonal NYSEG Supply Service (NSS)</name>
                                 <validityStatusDates>

--- a/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
+++ b/AGR/NYE/ELECTRIC/T002_SC1-All/XML/v0.99.7-dev/AGR_NYE_E_T002_SC1-All_tariff_books_2024-12-18T1300-5.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tariffBooks xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Flux-Tailor/rate-plan-schema/refs/tags/v0.99.7-dev/tariff_books.xsd">
+    <tariffBook isReplacementRecord="false" isDeletedRecord="false">
+        <utilityInfo>
+            <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
+            <organizationType>DistributedSystemPlatformProvider</organizationType>
+        </utilityInfo>
+        <commodity>electricityPrimaryMetered</commodity>
+        <dataSource>TariffBook</dataSource>
+        <mediaType>application/pdf</mediaType>
+        <sourceURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</sourceURL>
+        <dataCreationMethod>Manual</dataCreationMethod>
+        <dataDownloadURL>https://iedr-public-static-files.s3.amazonaws.com/rate-tariffs/new-york-state-electric-and-gas/electric/120/new-york-state-electric-and-gas_electric_120_effective.pdf</dataDownloadURL>
+        
+        <effectivePeriod>
+            <startDate>2010-01-01</startDate>
+        </effectivePeriod>
+        <datePublished>2023-12-18</datePublished>
+        <dateSourceLastUpdated>2024-12-18T13:00:00-05:00</dateSourceLastUpdated>
+        <dateTimeDataExtract>2024-12-18T13:00:00-05:00</dateTimeDataExtract>
+        <dateTimeDataTransfer>2024-12-18T13:51:00-05:00</dateTimeDataTransfer>
+        <updateFrequency>annually</updateFrequency>
+
+
+        <serviceClasses>
+            <serviceClass>
+                <serviceClassNumber>1</serviceClassNumber>
+                <serviceClassName>Service Classification No. 1</serviceClassName>
+                <tariffBookLeafRanges>
+                    <tariffBookLeafRange>
+                        <startLeafNumber>118</startLeafNumber>
+                        <startLeafMetadata>
+                            <receivedDate>2009-07-01</receivedDate>
+                            <initialEffectiveDate>2010-01-01</initialEffectiveDate>
+                            <effectiveDate>2010-01-01</effectiveDate>
+                            <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                            <status>EFFECTIVE</status>
+                            <revisionNumber>5</revisionNumber>
+                            <supersedingRevisionNumber>4</supersedingRevisionNumber>
+                        </startLeafMetadata>                        
+                        <endLeafNumber>127</endLeafNumber>     
+                    </tariffBookLeafRange>
+                </tariffBookLeafRanges>
+                <rates>
+                    <rate>
+                        <rateCode>SC01</rateCode>
+                        <rateName>Residential Straight</rateName>
+                        <tariffBookLeafRanges>
+                            <tariffBookLeafRange>
+                                <startLeafNumber>119</startLeafNumber>
+                                <startLeafMetadata>
+                                    <receivedDate>2023-10-27</receivedDate>
+                                    <initialEffectiveDate>2023-11-01</initialEffectiveDate>
+                                    <effectiveDate>2023-11-01</effectiveDate>
+                                    <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                    <status>EFFECTIVE</status>
+                                    <revisionNumber>18</revisionNumber>
+                                    <supersedingRevisionNumber>16</supersedingRevisionNumber>
+                                </startLeafMetadata>
+                                <endLeafNumber>123</endLeafNumber>
+                            </tariffBookLeafRange>
+                        </tariffBookLeafRanges>
+                        <ratePlans>
+                            <ratePlan ratePlanURI="https://iedr.nyserda.ny.gov/rate-plan/TODO">
+                                        <ratePlanIdentifiers>
+                                            <serviceClassNumber>1</serviceClassNumber>
+                                            <rateCode>SC01</rateCode>
+                                            <ratePlanCodeUnique>ERS-AGR-NYE-SC01-RES1</ratePlanCodeUnique>
+                                        </ratePlanIdentifiers> 
+                                        <commodity>electricityPrimaryMetered</commodity>
+                                        <utilityInfo>
+                                            <iedrOrgAbbreviation>NYE</iedrOrgAbbreviation>
+                                            <organizationType>DistributedSystemPlatformProvider</organizationType>
+                                        </utilityInfo>
+                                        <ratePlanApplicability>
+                                            <modelComponents>
+                                                <hasIcapTag>false</hasIcapTag>
+                                                <hasRetailSupply>false</hasRetailSupply>
+                                                <hasServiceTiers>true</hasServiceTiers>
+                                                <hasTimeOfUsePricing>false</hasTimeOfUsePricing>
+                                                <isRider>false</isRider>
+                                            </modelComponents>
+                                            <profile>
+                                                <customerClasses>
+                                                    <customerClass>Residential</customerClass>
+                                                    <!-- TODO: description removed since 0.99.5 --> 
+                                                </customerClasses>
+                                                <phases>
+                                                    <phase>none</phase>
+                                                    <!-- TODO: map existing description to phasecode - "Residential Customers: Continuous - Alternating Current, 60 Cycle; 120, 120/208, or 120/240 Volts - Single Phase. (Characteristics depend upon available circuits.) Religious, Veterans' Organizations, and Community Residence Supportive Living Facility Customers: Continuous - Alternating current, 60 cycle; Single or Three Phase. (Characteristics depend upon available circuits and equipment.)" -->
+                                                </phases>
+                                                
+                                            </profile>
+                                        </ratePlanApplicability>
+                                        <provenanceMetadata>
+                                            <tariffBookLeafRanges>
+                                                <tariffBookLeafRange>
+                                                    <startLeafNumber>119</startLeafNumber>
+                                                    <startLeafMetadata>
+                                                        <receivedDate>2023-10-27</receivedDate>
+                                                        <initialEffectiveDate>2023-11-01</initialEffectiveDate>
+                                                        <effectiveDate>2023-11-01</effectiveDate>
+                                                        <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                                        <status>EFFECTIVE</status>
+                                                        <revisionNumber>18</revisionNumber>
+                                                        <supersedingRevisionNumber>16</supersedingRevisionNumber>
+                                                    </startLeafMetadata>
+                                                    <endLeafNumber>119</endLeafNumber>
+                                                </tariffBookLeafRange>
+                                            </tariffBookLeafRanges>
+                                            <dpsCaseNumber>22-E-0317</dpsCaseNumber>
+                                            <iedrRatePlanBrowserURL></iedrRatePlanBrowserURL>
+                                            <tariffStatementTypeCode></tariffStatementTypeCode>
+                                        </provenanceMetadata>
+                                        <name>Service Classification No. 1</name>
+                                        <validityStatusDates>
+                                            <effectivePeriod>
+                                                <startDate>2023-11-01</startDate>
+                                            </effectivePeriod>
+                                        </validityStatusDates>
+                                        <description>Residential Straight</description>                                     
+                                        <holidays>
+                                            <!-- TODO: Holidays missing from 0.99.5 version --> 
+                                            <holidayName>Christmas Day</holidayName>
+                                        </holidays>
+                                    
+                                        <!-- TODO: I do not see any serviceTierThresholds for this ratePlan in the 0.99.5 version  -->    
+                                        <serviceTierThresholds>
+                                        </serviceTierThresholds>
+                                        
+                                        <!-- TODO: I do not see any timeOfUsePeriods for this ratePlan in the 0.99.5 version  -->
+                                        <timeOfUsePeriods>
+                                            <timeOfUsePeriod>
+                                            </timeOfUsePeriod>
+                                        </timeOfUsePeriods>
+                                    <charges>         
+                                        <minimumCharge>
+                                            <effectivePeriod>
+                                                <startDate>2023-11-01</startDate>
+                                                <endDate>2024-04-30</endDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Customer Charge</name>
+                                            <value>19.00</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_billing_cycle</calculationMethod>
+                                                <measurementInterval>
+                                                    <calculationMode>PERIOD</calculationMode>
+                                                    <calcIntervalKind>MONTH</calcIntervalKind>
+                                                    <calcIntervalPer>1</calcIntervalPer>
+                                                </measurementInterval>
+                                            </measurementDefinition>
+                                        </minimumCharge>
+                                        <minimumCharge>
+                                            <effectivePeriod>
+                                                <startDate>2024-05-01</startDate>
+                                                <endDate>2025-04-30</endDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Customer Charge</name>
+                                            <value>19.00</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_billing_cycle</calculationMethod>
+                                                <measurementInterval>
+                                                    <calculationMode>PERIOD</calculationMode>
+                                                    <calcIntervalKind>MONTH</calcIntervalKind>
+                                                    <calcIntervalPer>1</calcIntervalPer>
+                                                </measurementInterval>
+                                            </measurementDefinition>
+                                        </minimumCharge>
+                                        <minimumCharge>
+                                            <effectivePeriod>
+                                                <startDate>2025-05-01</startDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Customer Charge</name>
+                                            <value>19.00</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_billing_cycle</calculationMethod>
+                                                <measurementInterval>
+                                                    <calculationMode>PERIOD</calculationMode>
+                                                    <calcIntervalKind>MONTH</calcIntervalKind>
+                                                    <calcIntervalPer>1</calcIntervalPer>
+                                                </measurementInterval>
+                                            </measurementDefinition>
+                                        </minimumCharge>    
+                                        <otherFixedCharge>
+                                            <effectivePeriod>
+                                                <startDate>2023-11-01</startDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Bill Issuance Charge</name>
+                                            <value>.89</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_billing_cycle</calculationMethod>
+                                                <measurementInterval>
+                                                    <calculationMode>TOTAL</calculationMode>
+                                                    <calcIntervalKind>PER-CYCLE</calcIntervalKind>
+                                                    <calcIntervalPer>1</calcIntervalPer>
+                                                </measurementInterval>
+                                            </measurementDefinition>
+                                        </otherFixedCharge>
+                                        <meteredServiceCharge>
+                                            <effectivePeriod>
+                                                <startDate>2023-11-01</startDate>
+                                                <endDate>2024-04-30</endDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Energy Charge</name>
+                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                                plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                                customer’s bill shall not include the Make-Whole Rate.</description>
+                                            <value>0.06139</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_metered_quantity</calculationMethod>
+                                                <measurementSource>energy</measurementSource>
+                                                <unitOfMeasure>Wh</unitOfMeasure>
+                                            </measurementDefinition>
+                                        </meteredServiceCharge>
+                                        <meteredServiceCharge>
+                                            <effectivePeriod>
+                                                <startDate>2024-05-01</startDate>
+                                                <endDate>2025-04-30</endDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Energy Charge</name>
+                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                                plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                                customer’s bill shall not include the Make-Whole Rate.</description>
+                                            <value>0.07618</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_metered_quantity</calculationMethod>
+                                                <measurementSource>energy</measurementSource>
+                                                <unitOfMeasure>Wh</unitOfMeasure>
+                                            </measurementDefinition>
+                                        </meteredServiceCharge>
+                                        <meteredServiceCharge>
+                                            <effectivePeriod>
+                                                <startDate>2025-05-01</startDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Energy Charge</name>
+                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                                plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                                customer’s bill shall not include the Make-Whole Rate.</description>
+                                            <value>0.09507</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_metered_quantity</calculationMethod>
+                                                <measurementSource>energy</measurementSource>
+                                                <unitOfMeasure>Wh</unitOfMeasure>
+                                            </measurementDefinition>
+                                        </meteredServiceCharge>
+                                        <meteredServiceCharge>
+                                            <effectivePeriod>
+                                                <startDate>2023-11-01</startDate>
+                                                <endDate>2024-04-30</endDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Make-Whole Energy Charge</name>
+                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                                plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                                customer’s bill shall not include the Make-Whole Rate.</description>
+                                            <value>0.00276</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_metered_quantity</calculationMethod>
+                                                <measurementSource>energy</measurementSource>
+                                                <unitOfMeasure>Wh</unitOfMeasure>
+                                            </measurementDefinition>
+                                        </meteredServiceCharge>
+                                        <meteredServiceCharge>
+                                            <effectivePeriod>
+                                                <startDate>2024-05-01</startDate>
+                                                <endDate>2025-04-30</endDate>
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Make-Whole Energy Charge</name>
+                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                                plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                                customer’s bill shall not include the Make-Whole Rate.</description>
+                                            <value>0.00276</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_metered_quantity</calculationMethod>
+                                                <measurementSource>energy</measurementSource>
+                                                <unitOfMeasure>Wh</unitOfMeasure>
+                                            </measurementDefinition>
+                                        </meteredServiceCharge>
+                                        <meteredServiceCharge>
+                                            <effectivePeriod>
+                                                <startDate>2025-05-01</startDate>
+                                                <endDate>2026-04-30</endDate> 
+                                            </effectivePeriod>
+                                            <statementComponent>delivery</statementComponent>
+                                            <name>Make-Whole Energy Charge</name>
+                                            <description> The Delivery Charge that appears on the customer’s bill is the sum of the Energy Charge
+                                                plus the Make-Whole Charge. Effective May 1, 2026, the Make-Whole Rate shall expire and the Delivery Charge that appears on the
+                                                customer’s bill shall not include the Make-Whole Rate.</description>
+                                            <value>0.00276</value>
+                                            <measurementDefinition>
+                                                <calculationMethod>by_metered_quantity</calculationMethod>
+                                                <measurementSource>energy</measurementSource>
+                                                <unitOfMeasure>Wh</unitOfMeasure>
+                                            </measurementDefinition>
+                                        </meteredServiceCharge>
+                                    </charges>   
+                                </ratePlan>
+                            </ratePlans>
+                    </rate>
+                </rates>
+            </serviceClass>
+        </serviceClasses>
+    </tariffBook>
+</tariffBooks>


### PR DESCRIPTION
First draft of v0.99.7-dev compliant tariffBook for AGR NYE SC1 Electric.  

Outstanding questions and unknowns are indicated with `TODO`, and usually a comment. 

Note:  This file does not yet validate since I was unsure about some required elements - notably, holidays, serviceTierThresholds and timeOfUsePeriods were absent in v0.99.5 xml. 